### PR TITLE
Fix expression in MSBuild target

### DIFF
--- a/nupkg/build/netstandard2.0/AltCover.targets
+++ b/nupkg/build/netstandard2.0/AltCover.targets
@@ -7,7 +7,7 @@
 
   <Target Name="InstrumentModulesNoBuild" BeforeTargets="VSTest">
     <ItemGroup>
-      <SplitContext Include="$(CallContext).Split(';')" />
+      <SplitContext Include="$(CallContext.Split('%3B'))" />
     </ItemGroup>
     <AltCover.Prepare
       Condition="'$(VSTestNoBuild)' == 'true' and $(AltCover) == 'true'"
@@ -27,7 +27,7 @@
 
   <Target Name="InstrumentModulesAfterBuild" AfterTargets="BuildProject">
     <ItemGroup>
-      <SplitContext Include="$(CallContext).Split(';')" />
+      <SplitContext Include="$(CallContext.Split('%3B'))" />
     </ItemGroup>
     <AltCover.Prepare
       Condition="'$(VSTestNoBuild)' != 'true' and $(AltCover) == 'true'"


### PR DESCRIPTION
I was thinking about creating a `.targets` file and then noticed it was done just a few days ago. It mostly worked for me, but for some projects the `AltCover.Prepare` task would run forever. I noticed a problem with incorrect `SplitContext` value from looking at the verbose MSBuild log:
```
SplitContext=
    .Split('
    ')
```
It wasn't obviously related to the other problem, but this fix resolved the issue.

Unrelated: I'd suggest prefixing all the custom properties with "AltCover" to make them more self-documenting when referenced elsewhere and avoid potential collisions. Some of the properties like "FileFilter" and "XmlReport" are very generic sounding.