### PR TITLE
Routine SDK updates

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.4.12",
+      "version": "5.4.14",
       "commands": [
         "reportgenerator"
       ],

--- a/AltCover.Engine/Args.fs
+++ b/AltCover.Engine/Args.fs
@@ -106,7 +106,7 @@ module internal Args =
   let internal counts (args: Abstract.IPrepareOptions) =
     args
     |> countItems
-    |> List.collect (fun (a, b) -> { 0..b } |> Seq.map (fun _ -> a) |> Seq.toList)
+    |> List.collect (fun (a, b) -> seq { 0..b } |> Seq.map (fun _ -> a) |> Seq.toList)
 
   let prepare (args: Abstract.IPrepareOptions) =
     let argsList =
@@ -153,7 +153,7 @@ module internal Args =
     let counts (args: Abstract.ICollectOptions) =
       args
       |> countItems
-      |> List.collect (fun (a, b) -> { 0..b } |> Seq.map (fun _ -> a) |> Seq.toList)
+      |> List.collect (fun (a, b) -> seq { 0..b } |> Seq.map (fun _ -> a) |> Seq.toList)
 
     [ [ "Runner" ]
       item "-r" args.RecorderDirectory

--- a/AltCover.Engine/Args.fs
+++ b/AltCover.Engine/Args.fs
@@ -106,9 +106,9 @@ module internal Args =
   let internal counts (args: Abstract.IPrepareOptions) =
     args
     |> countItems
-      |> List.collect (fun (a, b) ->
-           let n = max 0 (b + 1)
-           List.replicate n a)
+    |> List.collect (fun (a, b) ->
+      let n = max 0 (b + 1)
+      List.replicate n a)
 
   let prepare (args: Abstract.IPrepareOptions) =
     let argsList =
@@ -156,8 +156,8 @@ module internal Args =
       args
       |> countItems
       |> List.collect (fun (a, b) ->
-           let n = max 0 (b + 1)
-           List.replicate n a)
+        let n = max 0 (b + 1)
+        List.replicate n a)
 
     [ [ "Runner" ]
       item "-r" args.RecorderDirectory

--- a/AltCover.Engine/Args.fs
+++ b/AltCover.Engine/Args.fs
@@ -106,7 +106,9 @@ module internal Args =
   let internal counts (args: Abstract.IPrepareOptions) =
     args
     |> countItems
-    |> List.collect (fun (a, b) -> seq { 0..b } |> Seq.map (fun _ -> a) |> Seq.toList)
+      |> List.collect (fun (a, b) ->
+           let n = max 0 (b + 1)
+           List.replicate n a)
 
   let prepare (args: Abstract.IPrepareOptions) =
     let argsList =
@@ -153,7 +155,9 @@ module internal Args =
     let counts (args: Abstract.ICollectOptions) =
       args
       |> countItems
-      |> List.collect (fun (a, b) -> seq { 0..b } |> Seq.map (fun _ -> a) |> Seq.toList)
+      |> List.collect (fun (a, b) ->
+           let n = max 0 (b + 1)
+           List.replicate n a)
 
     [ [ "Runner" ]
       item "-r" args.RecorderDirectory

--- a/Build/actions.fs
+++ b/Build/actions.fs
@@ -390,6 +390,7 @@ using System.Runtime.CompilerServices;
     CreateProcess.fromRawCommand file args
     |> CreateProcess.withWorkingDirectory dir
     |> CreateProcess.withFramework
+    |> CreateProcess.withEnvironment [("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "2")]
     |> Proc.run
     |> (AssertResult msg)
 

--- a/Build/actions.fs
+++ b/Build/actions.fs
@@ -390,7 +390,9 @@ using System.Runtime.CompilerServices;
     CreateProcess.fromRawCommand file args
     |> CreateProcess.withWorkingDirectory dir
     |> CreateProcess.withFramework
-    |> CreateProcess.withEnvironment [("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "2")]
+    |> CreateProcess.withEnvironment
+      [ ("DOTNET_ROLL_FORWARD", "Major")
+        ("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "2") ]
     |> Proc.run
     |> (AssertResult msg)
 

--- a/Build/targets.fs
+++ b/Build/targets.fs
@@ -1538,31 +1538,28 @@ module Targets =
         let gap = log.IndexOf ' '
         let commit = log.Substring gap
 
-        let options =
-          dotnetOptions
-          >> withWorkingDirectoryVN "_Reports"
-          >> dotnetOptionsWithRollForwards
-
-        let args =
-          "--opencover"
-          + " -i "
-          + coverage
-          + " --repoToken \""
-          + (Environment.environVar "COVERALLS_REPO_TOKEN")
-          + "\" --commitId "
-          + commitHash
-          + " --commitBranch "
-          + Information.getBranchName (".")
-          + " --commitAuthor \""
-          + (maybe "COMMIT_AUTHOR" "")
-          + "\" --commitEmail \""
-          + (maybe "COMMIT_AUTHOR_EMAIL" "")
-          + "\" --commitMessage \""
-          + commit
-          + "\" --jobId "
-          + DateTime.UtcNow.ToString("yyMMdd-HHmmss")
-
-        Actions.RunDotnet options "csmacnz.Coveralls" args "Coveralls upload failed"
+        Actions.Run
+          ("dotnet",
+           "_Reports",
+           [ "csmacnz.Coveralls"
+             "--opencover"
+             "-i"
+             coverage
+             "--repoToken"
+             Environment.environVar "COVERALLS_REPO_TOKEN"
+             "--commitId"
+             commitHash
+             "--commitBranch"
+             Information.getBranchName (".")
+             "--commitAuthor"
+             maybe "COMMIT_AUTHOR" ""
+             "--commitEmail"
+             maybe "COMMIT_AUTHOR_EMAIL" ""
+             "--commitMessage"
+             commit
+             "--jobId"
+             DateTime.UtcNow.ToString("yyMMdd-HHmmss") ])
+          "Coveralls upload failed"
 
       printfn "Dump uncovered lines"
 

--- a/Build/targets.fs
+++ b/Build/targets.fs
@@ -1538,28 +1538,31 @@ module Targets =
         let gap = log.IndexOf ' '
         let commit = log.Substring gap
 
-        Actions.Run
-          ("dotnet",
-           "_Reports",
-           [ "csmacnz.Coveralls"
-             "--opencover"
-             "-i"
-             coverage
-             "--repoToken"
-             Environment.environVar "COVERALLS_REPO_TOKEN"
-             "--commitId"
-             commitHash
-             "--commitBranch"
-             Information.getBranchName (".")
-             "--commitAuthor"
-             maybe "COMMIT_AUTHOR" ""
-             "--commitEmail"
-             maybe "COMMIT_AUTHOR_EMAIL" ""
-             "--commitMessage"
-             commit
-             "--jobId"
-             DateTime.UtcNow.ToString("yyMMdd-HHmmss") ])
-          "Coveralls upload failed"
+        let options =
+          dotnetOptions
+          >> withWorkingDirectoryVN "_Reports"
+          >> dotnetOptionsWithRollForwards
+
+        let args =
+          "--opencover"
+          + " -i "
+          + coverage
+          + " --repoToken "
+          + (Environment.environVar "COVERALLS_REPO_TOKEN")
+          + " --commitId "
+          + commitHash
+          + " --commitBranch "
+          + Information.getBranchName (".")
+          + " --commitAuthor "
+          + (maybe "COMMIT_AUTHOR" "")
+          + " --commitEmail "
+          + (maybe "COMMIT_AUTHOR_EMAIL" "")
+          + " --commitMessage "
+          + commit
+          + " --jobId "
+          + DateTime.UtcNow.ToString("yyMMdd-HHmmss")
+
+        Actions.RunDotnet options "csmacnz.Coveralls" args "Coveralls upload failed"
 
       printfn "Dump uncovered lines"
 

--- a/Build/targets.fs
+++ b/Build/targets.fs
@@ -1547,19 +1547,19 @@ module Targets =
           "--opencover"
           + " -i "
           + coverage
-          + " --repoToken "
+          + " --repoToken \""
           + (Environment.environVar "COVERALLS_REPO_TOKEN")
-          + " --commitId "
+          + "\" --commitId "
           + commitHash
           + " --commitBranch "
           + Information.getBranchName (".")
-          + " --commitAuthor "
+          + " --commitAuthor \""
           + (maybe "COMMIT_AUTHOR" "")
-          + " --commitEmail "
+          + "\" --commitEmail \""
           + (maybe "COMMIT_AUTHOR_EMAIL" "")
-          + " --commitMessage "
+          + "\" --commitMessage \""
           + commit
-          + " --jobId "
+          + "\" --jobId "
           + DateTime.UtcNow.ToString("yyMMdd-HHmmss")
 
         Actions.RunDotnet options "csmacnz.Coveralls" args "Coveralls upload failed"

--- a/Build/targets.fs
+++ b/Build/targets.fs
@@ -208,7 +208,9 @@ module Targets =
 
   let dotnetOptionsWithRollForwards (o: DotNet.Options) =
     let env =
-      o.Environment.Add("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "2")
+      o.Environment
+        .Add("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "2")
+        .Add("DOTNET_ROLL_FORWARD", "Major")
 
     o.WithEnvironment env
 
@@ -987,6 +989,7 @@ module Targets =
 
       let doLint f =
         CreateProcess.fromRawCommand "dotnet" [ "fsharplint"; "lint"; "-l"; cfg; f ]
+        |> CreateProcess.setEnvironmentVariable "DOTNET_ROLL_FORWARD" "Major"
         |> CreateProcess.setEnvironmentVariable
           "DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX"
           "2"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,10 +7,10 @@
     <PackageVersion Include="altcover" Version="9.0.1" />
     <PackageVersion Include="AltCover.Api" Version="9.0.1" />
     <PackageVersion Include="AltCover.Fake" Version="9.0.1" />
-    <PackageVersion Include="Avalonia" Version="11.3.4" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.4" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.4" />
-    <PackageVersion Include="Avalonia.Themes.Simple" Version="11.3.4" />
+    <PackageVersion Include="Avalonia" Version="11.3.6" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.3.6" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.6" />
+    <PackageVersion Include="Avalonia.Themes.Simple" Version="11.3.6" />
     <PackageVersion Include="BlackFox.CommandLine" Version="1.0.0" />
     <PackageVersion Include="BlackFox.VsWhere" Version="1.1.0" />
     <PackageVersion Include="Cake.Common" Version="5.0.0" />
@@ -43,7 +43,7 @@
     <PackageVersion Include="FuChu" Version="1.1.0" />
     <PackageVersion Include="GtkSharp" Version="3.24.24.95" />
     <PackageVersion Include="Handlebars.Net" Version="2.1.4" />
-    <PackageVersion Include="Markdig" Version="0.41.3" />
+    <PackageVersion Include="Markdig" Version="0.42.0" />
     <PackageVersion Include="ILRepack" Version="2.0.44" />
     <PackageVersion Include="MessageBox.Avalonia" Version="3.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="2.1.1" />
@@ -51,7 +51,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <!-- PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" / -->
-    <PackageVersion Include="Microsoft.Net.Sdk.Compilers.Toolset" Version="9.0.304" />
+    <PackageVersion Include="Microsoft.Net.Sdk.Compilers.Toolset" Version="9.0.305" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.14.1" />
@@ -61,7 +61,7 @@
     <PackageVersion Include="MSTest.TestFramework" Version="3.2.1" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.2.1" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NuGet.CommandLine" Version="6.14.0" />
     <PackageVersion Include="NUnit" Version="4.4.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.1.0" />
@@ -72,10 +72,10 @@
     <PackageVersion Include="OpenCover" Version="4.7.1221" />
     <PackageVersion Include="Pester" Version="5.7.1" />
     <PackageVersion Include="PowerShellStandard.Library" Version="5.1.1" />
-    <PackageVersion Include="System.Collections.Immutable" Version="9.0.8" />
+    <PackageVersion Include="System.Collections.Immutable" Version="9.0.9" />
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
-    <PackageVersion Include="System.Reactive.Core" Version="6.0.1" />
-    <PackageVersion Include="System.Security.Permissions" Version="9.0.8" />
+    <PackageVersion Include="System.Reactive.Core" Version="6.0.2" />
+    <PackageVersion Include="System.Security.Permissions" Version="9.0.9" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="Unquote" Version="7.0.1" />
     <PackageVersion Include="XmlDoc2CmdletDoc" Version="0.4.0-dotnetcore0001" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.304",
+    "version": "9.0.305",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
net 9.0.305 and other tooling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Upgraded key dependencies for improved stability and compatibility (Avalonia 11.3.6, Newtonsoft.Json 13.0.4, Markdig 0.42.0, System.* and others).
  - Updated .NET SDK to 9.0.305 and the coverage report tool to 5.4.14.
  - Enforced runtime roll-forward behavior during command execution to reduce framework mismatch issues.

- Refactor
  - Minor internal iteration and build environment adjustments with no user-facing impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->