### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,9 @@ on:
     branches:
     - master
 
+permissions:
+  contents: read
+
 # per https://www.meziantou.net/how-to-cancel-github-workflows-when-pushing-new-commits-on-a-branch.htm
 # https://docs.github.com/en/actions/learn-github-actions/expressions
 # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context


### PR DESCRIPTION
Potential fix for [https://github.com/SteveGilham/altcover/security/code-scanning/2](https://github.com/SteveGilham/altcover/security/code-scanning/2)

Add an explicit top-level `permissions` block in `.github/workflows/main.yml` so all jobs inherit least-privilege token access.

Best fix here (without changing behavior): add at workflow root:

```yml
permissions:
  contents: read
```

Place it after the `on:` block (or another top-level section) and before `jobs:`. This is enough for `actions/checkout` and typical CI read operations, and it satisfies the CodeQL recommendation while keeping functionality unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository automation settings to use read-only access for the default workflow token, improving security by limiting permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->